### PR TITLE
push tf and vscode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,6 @@
 *.cs        text diff=csharp
 *.csproj    text
 *.groovy    text
-*.json      text
-*.md        text
 *.proj      text
 *.projitems text
 *.props     text
@@ -40,7 +38,10 @@
 #   treat as text
 #   normalize to Unix-style line endings on check-in
 ###############################################################################
+*.json      text        eol=lf
+*.md        text        eol=lf
 *.sh        text        eol=lf
+*.ts        text        eol=lf
 *.tf        text        eol=lf
 *.tfvars    text        eol=lf
 gradlew     eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,64 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+########################################
+### Terraform
+########################################
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+########################################
+### VisualStudioCode 
+########################################
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+########################################
+### VisualStudioCode Patch
+########################################
+# Ignore all local history of files
+.history
+.ionide


### PR DESCRIPTION
# Background
Alot of dotnet microservices can be maintained by Visual Studio or VS Code. Further a lot of the service can be deployed using terraform. Having the gitattributes and gitignore configured for safe execution using GH Actions be default is a big help.

## Changes
<!--- Detail the technical changes that have been made -->
Add Gitignore and attributes for vs code and terraform

## Issue
#2 